### PR TITLE
add task which updates siri ride durations

### DIFF
--- a/airflow.yaml
+++ b/airflow.yaml
@@ -1,2 +1,3 @@
 dag_files:
   - open_bus_stride_etl/stats/dags.yaml
+  - open_bus_stride_etl/siri/dags.yaml

--- a/open_bus_stride_etl/cli.py
+++ b/open_bus_stride_etl/cli.py
@@ -1,6 +1,7 @@
 import click
 
 from .stats.cli import stats
+from .siri.cli import siri
 
 
 @click.group(context_settings={'max_content_width': 200})
@@ -10,3 +11,4 @@ def main():
 
 
 main.add_command(stats)
+main.add_command(siri)

--- a/open_bus_stride_etl/common.py
+++ b/open_bus_stride_etl/common.py
@@ -1,5 +1,19 @@
 import datetime
 
+import pytz
+
 
 def parse_siri_snapshot_id(snapshot_id):
     return datetime.datetime.strptime(snapshot_id + 'z+0000', '%Y/%m/%d/%H/%Mz%z')
+
+
+def now():
+    return datetime.datetime.now(pytz.UTC)
+
+
+def now_minus(**kwargs):
+    return now() - datetime.timedelta(**kwargs)
+
+
+def utc(dt: datetime.datetime):
+    return dt.astimezone(pytz.UTC)

--- a/open_bus_stride_etl/siri/add_ride_durations.py
+++ b/open_bus_stride_etl/siri/add_ride_durations.py
@@ -56,7 +56,7 @@ def main(session: Session):
                 first_row and last_row
                 and first_row.recorded_at_time
                 and last_row.recorded_at_time
-                and last_row.recorded_at_time > first_row.recorded_at_time
+                and first_row.recorded_at_time < last_row.recorded_at_time < datetime.datetime.now() - datetime.timedelta(hours=6)
         ):
             siri_ride.duration_minutes = round((last_row.recorded_at_time - first_row.recorded_at_time).total_seconds() / 60)
             stats['num_rows_updated_duration_minutes'] += 1

--- a/open_bus_stride_etl/siri/add_ride_durations.py
+++ b/open_bus_stride_etl/siri/add_ride_durations.py
@@ -1,0 +1,75 @@
+import datetime
+from pprint import pprint
+from textwrap import dedent
+from collections import defaultdict
+
+import pytz
+from sqlalchemy.engine import ResultProxy, Row
+
+from open_bus_stride_db.db import session_decorator, Session
+from open_bus_stride_db.model import SiriRide
+
+
+GET_FIRST_LAST_SQL_QUERY_TEMPLATE = dedent("""
+    select siri_vehicle_location.id, siri_vehicle_location.recorded_at_time
+    from siri_vehicle_location, siri_ride_stop, siri_ride
+    where siri_vehicle_location.siri_ride_stop_id = siri_ride_stop.id
+        and siri_ride_stop.siri_ride_id = siri_ride.id
+        and siri_ride.id = {siri_ride_id}
+    order by siri_vehicle_location.recorded_at_time {order_by} nulls last
+    limit 1
+""")
+
+
+@session_decorator
+def main(session: Session):
+    stats = defaultdict(int)
+    query = session.query(SiriRide).filter(SiriRide.updated_duration_minutes == None)
+    total_rows = query.count()
+    print("Total rows to update: {}".format(total_rows))
+    siri_ride: SiriRide
+    for siri_ride in query:
+        first_result: ResultProxy = session.execute(GET_FIRST_LAST_SQL_QUERY_TEMPLATE.format(
+            siri_ride_id=siri_ride.id, order_by='asc')
+        )
+        first_row: Row = first_result.one_or_none()
+        last_result: ResultProxy = session.execute(GET_FIRST_LAST_SQL_QUERY_TEMPLATE.format(
+            siri_ride_id=siri_ride.id, order_by='desc')
+        )
+        last_row: Row = last_result.one_or_none()
+        first_last_updated = False
+        if first_row and first_row.id != siri_ride.first_vehicle_location_id:
+            siri_ride.first_vehicle_location_id = first_row.id
+            first_last_updated = True
+            stats['num_rows_first_vehicle_location_updated'] += 1
+        elif last_row and last_row.id != siri_ride.last_vehicle_location_id:
+            siri_ride.last_vehicle_location_id = last_row.id
+            first_last_updated = True
+            stats['num_rows_last_vehicle_location_updated'] += 1
+        elif not siri_ride.updated_first_last_vehicle_locations:
+            first_last_updated = True
+            stats['num_rows_missing_first_last_last_updated'] += 1
+        if first_last_updated:
+            siri_ride.updated_first_last_vehicle_locations = datetime.datetime.now(pytz.UTC)
+        duration_minutes_updated = False
+        if (
+                first_row and last_row
+                and first_row.recorded_at_time
+                and last_row.recorded_at_time
+                and last_row.recorded_at_time > first_row.recorded_at_time
+        ):
+            siri_ride.duration_minutes = round((last_row.recorded_at_time - first_row.recorded_at_time).total_seconds() / 60)
+            stats['num_rows_updated_duration_minutes'] += 1
+            duration_minutes_updated = True
+        elif siri_ride.updated_first_last_vehicle_locations < datetime.datetime.now(pytz.UTC) - datetime.timedelta(days=2):
+            stats['num_rows_too_old_not_updated_duration_minutes'] += 1
+            duration_minutes_updated = True
+        if duration_minutes_updated:
+            siri_ride.updated_duration_minutes = datetime.datetime.now(pytz.UTC)
+        stats['num_rows'] += 1
+        if stats['num_rows'] % 10000 == 0:
+            pprint(dict(stats))
+            print("Processed {} / {} rows..".format(stats['num_rows'], total_rows))
+    pprint(dict(stats))
+    print("Committing..")
+    session.commit()

--- a/open_bus_stride_etl/siri/cli.py
+++ b/open_bus_stride_etl/siri/cli.py
@@ -1,0 +1,14 @@
+import click
+
+
+@click.group()
+def siri():
+    """Handle processing of SIRI data"""
+    pass
+
+
+@siri.command()
+def add_ride_durations():
+    """add duration of rides based on vehicle locations to siri_ride table"""
+    from .add_ride_durations import main
+    main()

--- a/open_bus_stride_etl/siri/dags.yaml
+++ b/open_bus_stride_etl/siri/dags.yaml
@@ -1,0 +1,10 @@
+- name: stride-etl-siri-add-ride-durations
+  schedule_interval: "@hourly"
+  description: |
+    Add duration minutes to all rides
+  tasks:
+    - id: siri-add-ride-durations
+      config:
+        type: cli
+        module: open_bus_stride_etl.siri.cli
+        function: add_ride_durations


### PR DESCRIPTION
 * The task runs hourly via airflow and iterates over all ride objects which were not updated with ride duration yet.
 * For each ride it gets the first/last siri vehicle location (based on vehicle location recorded_at_time)
 * Saves the first/last vehicle location id in the ride object
 * Updates the ride duration in minutes based on this
 * Waits up to 6 hours since the last vehicle location before updating the duration (giving time for delay in processing)

This PR depends on DB changes: https://github.com/hasadna/open-bus-stride-db/pull/5