### PR TITLE
add siri update rides gtfs command + misc. fixes and changes

### DIFF
--- a/open_bus_stride_etl/common.py
+++ b/open_bus_stride_etl/common.py
@@ -21,13 +21,29 @@ def utc(dt: datetime.datetime):
     return dt.astimezone(pytz.UTC)
 
 
-def parse_date_str(date):
-    """Parses a date string in format %Y-%m-%d with default of today if empty"""
+def parse_date_str(date, num_days=None):
+    """Parses a date string in format %Y-%m-%d with default of today if empty
+    if num_days is not None - will use a default of today minus given num_days
+    """
     if isinstance(date, datetime.date):
         return date
-    if not date or date == 'None':
-        return datetime.date.today()
-    return datetime.datetime.strptime(date, '%Y-%m-%d').date()
+    elif not date or date is 'None':
+        return datetime.date.today() if num_days is None else datetime.date.today() - datetime.timedelta(days=num_days)
+    else:
+        return datetime.datetime.strptime(date, '%Y-%m-%d').date()
+
+
+def parse_min_max_date_strs(min_date, max_date, num_days=None):
+    """Parses min/max date strings in format %Y-%m-%d
+     min_date default = today minus num_days
+     max_date default = today"""
+    min_date, max_date = parse_date_str(min_date, num_days), parse_date_str(max_date)
+    assert min_date <= max_date
+    return min_date, max_date
+
+
+def get_db_date_str(d):
+    return d.strftime('%Y-%m-%d')
 
 
 @contextmanager

--- a/open_bus_stride_etl/siri/cli.py
+++ b/open_bus_stride_etl/siri/cli.py
@@ -15,14 +15,30 @@ def add_ride_durations():
 
 
 @siri.command()
-def update_ride_stops_gtfs():
+@click.option('--min-date', help='Date string (%Y-%m-%d) specifying the min date to process. Defaults to today minus num_days if not provided.')
+@click.option('--max-date', help='Date string (%Y-%m-%d) specifying the max date to process. Defaults to today if not provided.')
+@click.option('--num-days', default=1, show_default=True, help='min_date defaults to today minus num_days if not provided')
+def update_ride_stops_gtfs(**kwargs):
     """update siri_ride_stop table with the related gtfs_stop data"""
     from .update_ride_stops_gtfs import main
-    main()
+    main(**kwargs)
 
 
 @siri.command()
-def update_ride_stops_vehicle_locations():
+@click.option('--min-date', help='Date string (%Y-%m-%d) specifying the min date to process. Defaults to today minus num_days if not provided.')
+@click.option('--max-date', help='Date string (%Y-%m-%d) specifying the max date to process. Defaults to today if not provided.')
+@click.option('--num-days', default=1, show_default=True, help='min_date defaults to today minus num_days if not provided')
+def update_ride_stops_vehicle_locations(**kwargs):
     """update ride_stops with vehicle_location nearest each stop by gtfs lon/lat"""
     from .update_ride_stops_vehicle_locations import main
-    main()
+    main(**kwargs)
+
+
+@siri.command()
+@click.option('--min-date', help='Date string (%Y-%m-%d) specifying the min date to process. Defaults to today minus num_days if not provided.')
+@click.option('--max-date', help='Date string (%Y-%m-%d) specifying the max date to process. Defaults to today if not provided.')
+@click.option('--num-days', default=1, show_default=True, help='min_date defaults to today minus num_days if not provided')
+def update_rides_gtfs(**kwargs):
+    """Update siri rides data with related gtfs data"""
+    from .update_rides_gtfs import main
+    main(**kwargs)

--- a/open_bus_stride_etl/siri/dags.yaml
+++ b/open_bus_stride_etl/siri/dags.yaml
@@ -1,13 +1,19 @@
-- name: stride-etl-siri-updates
+- name: stride-etl-siri-add-ride-durations
   schedule_interval: "@hourly"
   description: |
-    Updates for SIRI data
+    add siri ride durations
   tasks:
     - id: siri-add-ride-durations
       config:
         type: cli
         module: open_bus_stride_etl.siri.cli
         function: add_ride_durations
+
+- name: stride-etl-siri-update-ride-stops-gtfs
+  schedule_interval: "@hourly"
+  description: |
+    update siri ride-stops with gtfs data
+  tasks:
     - id: siri-update-ride-stops-gtfs
       depends_on:
         - siri-add-ride-durations
@@ -15,6 +21,16 @@
         type: cli
         module: open_bus_stride_etl.siri.cli
         function: update_ride_stops_gtfs
+        kwargs:
+          min_date: {}
+          max_date: {}
+          num_days: {default: "1"}
+
+- name: stride-etl-siri-update-ride-stops-vehicle-locations
+  schedule_interval: "@hourly"
+  description: |
+    update siri ride-stops and vehicle locations
+  tasks:
     - id: siri-update-ride-stops-vehicle-locations
       depends_on:
         - siri-update-ride-stops-gtfs
@@ -22,3 +38,22 @@
         type: cli
         module: open_bus_stride_etl.siri.cli
         function: update_ride_stops_vehicle_locations
+        kwargs:
+          min_date: {}
+          max_date: {}
+          num_days: {default: "1"}
+
+- name: stride-etl-siri-update-rides-gtfs
+  schedule_interval: "@hourly"
+  description: |
+    Update siri_ride with related gtfs_ride
+  tasks:
+    - id: siri-update-rides-gtfs
+      config:
+        type: cli
+        module: open_bus_stride_etl.siri.cli
+        function: update-rides-gtfs
+        kwargs:
+          min_date: {}
+          max_date: {}
+          num_days: {default: "1"}

--- a/open_bus_stride_etl/siri/update_ride_stops_gtfs.py
+++ b/open_bus_stride_etl/siri/update_ride_stops_gtfs.py
@@ -8,22 +8,29 @@ from sqlalchemy.engine import ResultProxy
 from open_bus_stride_db import db
 
 from .common import iterate_siri_route_id_dates
+from ..common import parse_min_max_date_strs, get_db_date_str
 
 
-def main():
+def main(min_date, max_date, num_days):
+    min_date, max_date = parse_min_max_date_strs(min_date, max_date, num_days)
+    print(f'min_date={min_date}')
+    print(f'max_date={max_date}')
     stats = defaultdict(int)
     for date, siri_route_ids in iterate_siri_route_id_dates(
         extra_from_sql='gtfs_stop, siri_stop, siri_ride_stop',
         where_sql=dedent("""
             siri_ride_stop.siri_stop_id = siri_stop.id
             and siri_ride_stop.siri_ride_id = siri_ride.id
+            -- if we have updated_duration_minutes it means we updated the duration of the ride
+            -- so we have all the ride stops data which we must ensure before making these updates
             and siri_ride.updated_duration_minutes is not null
             and siri_ride_stop.gtfs_stop_id is null
             and gtfs_stop.code = siri_stop.code
             and gtfs_stop.date >= '{min_date}'
             and siri_ride.scheduled_start_time >= '{min_date}'
+            and siri_ride.scheduled_start_time <= '{max_date}'
             and gtfs_stop.date = date_trunc('day', siri_ride.scheduled_start_time)
-        """).format(min_date=(datetime.datetime.now() - datetime.timedelta(days=1)).strftime('%Y-%m-%d'))
+        """).format(min_date=get_db_date_str(min_date), max_date=get_db_date_str(max_date))
     ):
         for siri_route_id in siri_route_ids:
             stats['updated_siri_routes'] += 1

--- a/open_bus_stride_etl/siri/update_rides_gtfs.py
+++ b/open_bus_stride_etl/siri/update_rides_gtfs.py
@@ -1,0 +1,107 @@
+import datetime
+from pprint import pprint
+from textwrap import dedent
+from collections import defaultdict
+
+from open_bus_stride_db import db
+
+from .common import iterate_siri_route_id_dates
+from ..common import parse_min_max_date_strs, get_db_date_str
+
+
+UPDATE_ROUTE_GTFS_RIDE_SQL_TEMPLATE = dedent("""
+    update siri_ride
+    set route_gtfs_ride_id = gtfs_ride.id
+    from gtfs_ride, gtfs_route, siri_route
+    where 
+    gtfs_route.id = gtfs_ride.gtfs_route_id
+    and gtfs_route.operator_ref = siri_route.operator_ref
+    and gtfs_route.line_ref = siri_route.line_ref
+    and siri_route.id = siri_ride.siri_route_id
+    and gtfs_route.date = '{date}'
+    and siri_ride.scheduled_start_time > gtfs_ride.start_time - '{minutes} minutes'::interval
+    and siri_ride.scheduled_start_time < gtfs_ride.start_time + '{minutes} minutes'::interval
+    -- if we have updated_duration_minutes it means we updated the duration of the ride
+    -- so we have all the ride stops data which we must ensure before making these updates
+    and siri_ride.updated_duration_minutes is not null
+    {extra_where}
+""")
+
+def main(min_date, max_date, num_days):
+    min_date, max_date = parse_min_max_date_strs(min_date, max_date, num_days)
+    print(f'min_date={min_date}')
+    print(f'max_date={max_date}')
+    stats = defaultdict(int)
+    for date, siri_route_ids in iterate_siri_route_id_dates(
+        where_sql=dedent("""
+            siri_ride.gtfs_ride_id is null
+            and siri_ride.scheduled_start_time >= '{min_date}'
+            and siri_ride.scheduled_start_time <= '{max_date}'
+            -- if we have updated_duration_minutes it means we updated the duration of the ride
+            -- so we have all the ride stops data which we must ensure before making these updates
+            and siri_ride.updated_duration_minutes is not null
+        """).format(min_date=get_db_date_str(min_date), max_date=get_db_date_str(max_date))
+    ):
+        updated_journey_gtfs_ride_ids = 0
+        updated_route_gtfs_ride_ids = 0
+        updated_gtfs_ride_ids_by_route = 0
+        updated_gtfs_ride_ids_by_journey = 0
+        with db.get_session() as session:
+            res = session.execute(dedent("""
+                set local synchronous_commit to off;
+                update siri_ride
+                set journey_gtfs_ride_id = gtfs_ride.id
+                from gtfs_ride, gtfs_route
+                where gtfs_ride.journey_ref = split_part(siri_ride.journey_ref, '-', 4) || '_' || split_part(siri_ride.journey_ref, '-', 3) || split_part(siri_ride.journey_ref, '-', 2) || substr(split_part(siri_ride.journey_ref, '-', 1), 3)
+                and gtfs_route.id = gtfs_ride.gtfs_route_id
+                and gtfs_route.date = '{}';
+                -- if we have updated_duration_minutes it means we updated the duration of the ride
+                -- so we have all the ride stops data which we must ensure before making these updates
+                and siri_ride.updated_duration_minutes is not null
+            """).format(date))
+            updated_journey_gtfs_ride_ids += res.rowcount
+            updated_route_gtfs_ride_ids += session.execute(
+                UPDATE_ROUTE_GTFS_RIDE_SQL_TEMPLATE.format(
+                    date=date, minutes='1',
+                    extra_where=''
+                )
+            ).rowcount
+            updated_route_gtfs_ride_ids += session.execute(
+                UPDATE_ROUTE_GTFS_RIDE_SQL_TEMPLATE.format(
+                    date=date, minutes='3',
+                    extra_where='and siri_ride.route_gtfs_ride_id is null'
+                )
+            ).rowcount
+            updated_route_gtfs_ride_ids += session.execute(
+                UPDATE_ROUTE_GTFS_RIDE_SQL_TEMPLATE.format(
+                    date=date, minutes='5',
+                    extra_where='and siri_ride.route_gtfs_ride_id is null'
+                )
+            ).rowcount
+            updated_gtfs_ride_ids_by_route += session.execute(dedent("""
+                update siri_ride
+                set gtfs_ride_id = gtfs_ride.id
+                from gtfs_ride, gtfs_route
+                where gtfs_ride.id = siri_ride.route_gtfs_ride_id
+                and gtfs_route.id = gtfs_ride.gtfs_route_id
+                and gtfs_route.date = '{}'
+                and siri_ride.journey_gtfs_ride_id is null
+            """).format(date)).rowcount
+            updated_gtfs_ride_ids_by_journey += session.execute(dedent("""
+                update siri_ride
+                set gtfs_ride_id = gtfs_ride.id
+                from gtfs_ride, gtfs_route
+                where gtfs_ride.id = siri_ride.journey_gtfs_ride_id
+                and gtfs_route.id = gtfs_ride.gtfs_route_id
+                and gtfs_route.date = '{}'
+            """).format(date)).rowcount
+            session.commit()
+        print(f"Updated route gtfs ride ids: {updated_route_gtfs_ride_ids}")
+        print(f"Updated journey gtfs ride ids: {updated_journey_gtfs_ride_ids}")
+        print(f"Updated gtfs ride ids by journey: {updated_gtfs_ride_ids_by_journey}")
+        print(f"Updated gtfs ride ids by route: {updated_gtfs_ride_ids_by_route}")
+        stats['updated_route_gtfs_ride_ids'] += updated_route_gtfs_ride_ids
+        stats['updated_journey_gtfs_ride_ids'] += updated_journey_gtfs_ride_ids
+        stats['updated_gtfs_ride_ids_by_journey'] += updated_gtfs_ride_ids_by_journey
+        stats['updated_gtfs_ride_ids_by_route'] += updated_gtfs_ride_ids_by_route
+        pprint(dict(stats))


### PR DESCRIPTION
* siri update_ride_stops_gtfs, update_ride_stops_vehicle_locations: add min_date, max_date, num_days params to allow running for past dates from airflow
* add siri update_rides_gtfs: updates siri_ride table with gtfs_ride ids (depends on hasadna/open-bus-stride-db#12)
* split the siri airflow dag to separate dags as they are not dependant on each other, allowing to manually run each task for past dates