### PR TITLE
siri: prefer exact scheduled-time over journey_ref when matching gtfs rides

### DIFF
--- a/open_bus_stride_etl/siri/update_rides_gtfs.py
+++ b/open_bus_stride_etl/siri/update_rides_gtfs.py
@@ -61,6 +61,7 @@ def main(min_date, max_date, num_days):
         updated_journey_gtfs_ride_ids = 0
         updated_route_gtfs_ride_ids = 0
         updated_scheduled_gtfs_ride_ids = 0
+        updated_gtfs_ride_ids_by_scheduled = 0
         updated_gtfs_ride_ids_by_route = 0
         updated_gtfs_ride_ids_by_journey = 0
         with db.get_session() as session:
@@ -95,6 +96,27 @@ def main(min_date, max_date, num_days):
                     extra_where='and siri_ride.route_gtfs_ride_id is null'
                 )
             ).rowcount
+            # Compute the exact scheduled-time match (siri.scheduled_start_time = gtfs.start_time).
+            updated_scheduled_gtfs_ride_ids += session.execute(
+                UPDATE_SCHEDULED_GTFS_RIDE_SQL_TEMPLATE.format(
+                    start_date=date, end_date=get_tommorow_date(date),
+                )
+            ).rowcount
+            # Assign the final gtfs_ride_id by priority: exact scheduled-time match first
+            # (bulletproof and stable across GTFS feed versions), then the fuzzy time
+            # (route) match, and only then the journey_ref match as a last tiebreaker.
+            # journey_ref must NOT take priority: the operator's real-time trip id only
+            # matches the GTFS trip_id ~3 days/week network-wide, so it is unreliable and
+            # has no time verification. Each step only fills rows still unassigned.
+            updated_gtfs_ride_ids_by_scheduled += session.execute(dedent("""
+                update siri_ride
+                set gtfs_ride_id = gtfs_ride.id
+                from gtfs_ride, gtfs_route
+                where gtfs_ride.id = siri_ride.scheduled_time_gtfs_ride_id
+                and gtfs_route.id = gtfs_ride.gtfs_route_id
+                and gtfs_route.date between '{date}' and '{tomorrow}'
+                and siri_ride.gtfs_ride_id is null
+            """).format(date=date, tomorrow=get_tommorow_date(date))).rowcount
             updated_gtfs_ride_ids_by_route += session.execute(dedent("""
                 update siri_ride
                 set gtfs_ride_id = gtfs_ride.id
@@ -102,7 +124,7 @@ def main(min_date, max_date, num_days):
                 where gtfs_ride.id = siri_ride.route_gtfs_ride_id
                 and gtfs_route.id = gtfs_ride.gtfs_route_id
                 and gtfs_route.date = '{}'
-                and siri_ride.journey_gtfs_ride_id is null
+                and siri_ride.gtfs_ride_id is null
             """).format(date)).rowcount
             updated_gtfs_ride_ids_by_journey += session.execute(dedent("""
                 update siri_ride
@@ -111,19 +133,17 @@ def main(min_date, max_date, num_days):
                 where gtfs_ride.id = siri_ride.journey_gtfs_ride_id
                 and gtfs_route.id = gtfs_ride.gtfs_route_id
                 and gtfs_route.date = '{}'
+                and siri_ride.gtfs_ride_id is null
             """).format(date)).rowcount
-            updated_scheduled_gtfs_ride_ids += session.execute(
-                UPDATE_SCHEDULED_GTFS_RIDE_SQL_TEMPLATE.format(
-                    start_date=date, end_date=get_tommorow_date(date),
-                )
-            ).rowcount
             session.commit()
         print(f"Updated route gtfs ride ids: {updated_route_gtfs_ride_ids}")
         print(f"Updated journey gtfs ride ids: {updated_journey_gtfs_ride_ids}")
+        print(f"Updated gtfs ride ids by scheduled: {updated_gtfs_ride_ids_by_scheduled}")
         print(f"Updated gtfs ride ids by journey: {updated_gtfs_ride_ids_by_journey}")
         print(f"Updated gtfs ride ids by route: {updated_gtfs_ride_ids_by_route}")
         stats['updated_route_gtfs_ride_ids'] += updated_route_gtfs_ride_ids
         stats['updated_journey_gtfs_ride_ids'] += updated_journey_gtfs_ride_ids
+        stats['updated_gtfs_ride_ids_by_scheduled'] += updated_gtfs_ride_ids_by_scheduled
         stats['updated_gtfs_ride_ids_by_journey'] += updated_gtfs_ride_ids_by_journey
         stats['updated_gtfs_ride_ids_by_route'] += updated_gtfs_ride_ids_by_route
         pprint(dict(stats))


### PR DESCRIPTION
# siri: prefer exact scheduled-time over journey_ref when matching gtfs rides

## Problem

When `update_rides_gtfs` assigns the final `siri_ride.gtfs_ride_id`, it currently **prefers the `journey_ref` match**: the route/time update is gated `WHERE journey_gtfs_ride_id IS NULL`, so the journey match wins whenever it fired. The exact scheduled-time match that the same task computes (`scheduled_time_gtfs_ride_id`) is **never used** to set `gtfs_ride_id`.

But `journey_ref` matching is unreliable. The operator's SIRI `DatedVehicleJourneyRef` (the number in `siri_ride.journey_ref`) only equals the GTFS `trip_id` prefix part of the time — it changes **every day**, while the GTFS trip prefix is stable across days. So the two coincide only **~3 days per week**, and the pattern is **system-wide** (the same weekly collapse happens for different operators). Meanwhile the planned `scheduled_start_time` is identical in both feeds and matches **every day**.

The journey match also has **no time verification** (it joins purely on the transformed `journey_ref` + `gtfs_route.date`), so when preferred it can override a correct time match.

## Evidence (reproducible against the public API)

This script needs only Python stdlib and the public stride-api — no DB or auth. It compares, per day, the `journey_ref` match rate vs the `scheduled_start_time` match rate for two lines from two operators:

```python
#!/usr/bin/env python3
"""
Reproduces the justification for preferring exact scheduled_start_time over
journey_ref when matching SIRI rides to GTFS rides.

For two lines (Egged 480, Dan 1) over 2 weeks it prints, per day:
  - journey_ref match%   : do the GTFS trip_id prefixes equal the SIRI journey numbers?
  - scheduled_time match% : do the GTFS start_times equal the SIRI scheduled_start_times?

Expected: journey_ref collapses to 0% several days every week (and differs by
operator), while scheduled_time stays high every single day. Uses only the public
stride-api + stdlib; no auth/DB needed.
"""
import urllib.request, json, datetime

API = "https://open-bus-stride-api.hasadna.org.il"
def get(path):
    with urllib.request.urlopen(API + path, timeout=60) as r:
        return json.load(r)

def day_stats(route_short_name, operator_ref, date):
    # planned (GTFS) rides for this line+operator on `date`, direction 1
    routes = [r for r in get(
        f"/gtfs_routes/list?route_short_name={route_short_name}"
        f"&operator_refs={operator_ref}&date_from={date}&date_to={date}&limit=30")
        if str(r.get('date',''))[:10] == date and r.get('route_direction') == '1']
    if not routes:
        return None
    route = sorted(routes, key=lambda r: str(r.get('route_alternative')))[0]
    line_ref = route['line_ref']
    g = get(f"/gtfs_rides/list?gtfs_route_id={route['id']}&limit=800")
    g_times    = {x['start_time']               for x in g if x.get('start_time')}
    g_prefixes = {x['journey_ref'].split('_')[0] for x in g if x.get('journey_ref')}

    # actual (SIRI) rides for the SAME line_ref  (NOTE the double underscore in the param)
    s = get(f"/siri_rides/list?siri_route__line_refs={line_ref}"
            f"&siri_route__operator_refs={operator_ref}"
            f"&scheduled_start_time_from={date}T00:00:00%2B00:00"
            f"&scheduled_start_time_to={date}T23:59:00%2B00:00&limit=4000")
    s_times   = {x['scheduled_start_time']        for x in s if x.get('scheduled_start_time')}
    s_numbers = {x['journey_ref'].split('-')[3]   for x in s
                 if x.get('journey_ref') and len(x['journey_ref'].split('-')) >= 4}

    journey_pct   = 100 * len(g_prefixes & s_numbers) // max(len(g_prefixes), 1)
    scheduled_pct = 100 * len(g_times    & s_times)   // max(len(g_times), 1)
    return journey_pct, scheduled_pct

DOW = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun']
for route_short_name, operator_ref, label in [("480","3","Egged"), ("1","5","Dan")]:
    print(f"\n=== line {route_short_name} ({label}, operator {operator_ref}) ===")
    print(f"{'date':12}{'dow':5}{'journey_ref match%':>20}{'scheduled_time match%':>24}")
    d0 = datetime.date(2026, 5, 1)
    for i in range(14):
        d = d0 + datetime.timedelta(days=i)
        st = day_stats(route_short_name, operator_ref, d.isoformat())
        if st:
            print(f"{d.isoformat():12}{DOW[d.weekday()]:5}{st[0]:>17}%{st[1]:>22}%")
```

### Output (verified 2026-06)

`journey_ref` collapses to 0% several days every week (and the bad days differ by operator), while `scheduled_time` stays high **every** day:

```
=== line 480 (Egged, operator 3) ===
date        dow    journey_ref match%   scheduled_time match%
2026-05-01  Fri                 79%                    97%
2026-05-02  Sat                 95%                   100%
2026-05-03  Sun                 97%                    97%
2026-05-04  Mon                100%                   100%
2026-05-05  Tue                  0%                    97%
2026-05-06  Wed                  0%                    97%
2026-05-07  Thu                  0%                    97%
2026-05-08  Fri                 79%                    97%
2026-05-09  Sat                 95%                   100%
2026-05-10  Sun                 94%                    94%
2026-05-11  Mon                  0%                    97%
2026-05-12  Tue                  0%                    97%
2026-05-13  Wed                  0%                    94%
2026-05-14  Thu                  0%                    97%

=== line 1 (Dan, operator 5) ===
date        dow    journey_ref match%   scheduled_time match%
2026-05-01  Fri                 73%                    88%
2026-05-02  Sat                 57%                   100%
2026-05-03  Sun                 90%                    90%
2026-05-04  Mon                100%                   100%
2026-05-05  Tue                 93%                    93%
2026-05-06  Wed                  0%                    96%
2026-05-07  Thu                  0%                    92%
2026-05-08  Fri                 73%                    88%
2026-05-09  Sat                 57%                   100%
2026-05-10  Sun                 91%                    91%
2026-05-11  Mon                  0%                    96%
2026-05-12  Tue                  0%                    96%
2026-05-13  Wed                  0%                    96%
2026-05-14  Thu                  0%                    94%
```

(The `scheduled_time` rate is <100% only because some planned rides are genuine no-shows; it never collapses the way `journey_ref` does.)

## Fix

Assign `gtfs_ride_id` by **priority**, each step filling only rows still unassigned (`siri_ride.gtfs_ride_id IS NULL`):

1. **exact `scheduled_start_time`** match (`scheduled_time_gtfs_ride_id`) — primary
2. **fuzzy ±1/3/5 min** match (`route_gtfs_ride_id`) — fallback
3. **`journey_ref`** match (`journey_gtfs_ride_id`) — last tiebreaker

Adds an `Updated gtfs ride ids by scheduled` counter/stat. `journey_ref` is still used (as a tiebreaker), so no matches are lost — the change only stops the unreliable signal from overriding the reliable one.

## Scope / note

This PR only re-orders the matcher priority. It does **not** address the separate upstream issue that the `add-ride-durations` DAG is disabled and the `updated_duration_minutes` gate currently blocks this matcher from running at all (`siri_ride.gtfs_ride_id` has been NULL network-wide since ~Oct 2024). That needs its own fix + historical backfill.
