### PR TITLE
fix: restore add-ride-durations DAG splitted into batches to prevent OOM

### DIFF
--- a/open_bus_stride_etl/siri/add_ride_durations.py
+++ b/open_bus_stride_etl/siri/add_ride_durations.py
@@ -9,6 +9,18 @@ from open_bus_stride_db.model import SiriRide
 from open_bus_stride_etl import common
 
 
+# Number of siri_ride rows fetched and processed per batch. We must NOT load the
+# whole result set at once: with psycopg2 + SQLAlchemy<2 a plain `for x in query`
+# uses a client-side buffered cursor that materializes every matching row (plus
+# its ORM object) in memory. That is exactly what caused the OOM that got this
+# task disabled in Nov 2024 (https://github.com/hasadna/open-bus-stride-etl/issues/22):
+# fine for a 4-day window, fatal once a backlog built up. We instead paginate by
+# primary key (keyset) so memory is bounded to BATCH_SIZE rows regardless of how
+# far behind the task is. A server-side cursor (stream_results) is not an option
+# here because we commit mid-iteration, which would invalidate the cursor.
+BATCH_SIZE = 1000
+
+
 # we don't use a limit in this query due to a known PostgreSQL bug: https://www.postgresql.org/message-id/flat/CA%2BU5nMLbXfUT9cWDHJ3tpxjC3bTWqizBKqTwDgzebCB5bAGCgg%40mail.gmail.com
 # because this query always returns a low number of rows, we limit the number of rows in the code
 GET_FIRST_LAST_SQL_QUERY_TEMPLATE = dedent("""
@@ -71,23 +83,35 @@ def update_duration_minutes(siri_ride, first_row, last_row, stats):
 @session_decorator
 def main(session: Session):
     stats = defaultdict(int)
-    query = session.query(SiriRide).filter(
-        SiriRide.updated_duration_minutes == None,
-        SiriRide.scheduled_start_time > common.now_minus(days=4)
-    )
-    total_rows = query.count()
+    base_filter = SiriRide.scheduled_start_time > common.now_minus(days=4)
+    total_rows = session.query(SiriRide).filter(
+        SiriRide.updated_duration_minutes == None, base_filter
+    ).count()
     print("Total rows to update: {}".format(total_rows))
+    # Keyset pagination: walk the matching rows ordered by primary key, fetching
+    # at most BATCH_SIZE ORM objects at a time. Each row we process either gets
+    # updated_duration_minutes set (dropping out of the filter) or stays NULL to
+    # be retried on a later run; either way the `id > last_id` bound guarantees
+    # forward progress within this run, so there is no risk of an infinite loop.
+    last_id = 0
     siri_ride: SiriRide
-    for siri_ride in query:
-        first_row = get_first_last_row(session, siri_ride.id, 'asc')
-        last_row = get_first_last_row(session, siri_ride.id, 'desc')
-        update_first_last_vehicle_locations(siri_ride, first_row, last_row, stats)
-        update_duration_minutes(siri_ride, first_row, last_row, stats)
-        stats['num_rows'] += 1
-        if stats['num_rows'] % 10000 == 0:
-            pprint(dict(stats))
-            print("Processed {} / {} rows..".format(stats['num_rows'], total_rows))
-            session.commit()
+    while True:
+        rides = session.query(SiriRide).filter(
+            SiriRide.updated_duration_minutes == None,
+            SiriRide.id > last_id,
+            base_filter
+        ).order_by(SiriRide.id).limit(BATCH_SIZE).all()
+        if not rides:
+            break
+        for siri_ride in rides:
+            last_id = siri_ride.id
+            first_row = get_first_last_row(session, siri_ride.id, 'asc')
+            last_row = get_first_last_row(session, siri_ride.id, 'desc')
+            update_first_last_vehicle_locations(siri_ride, first_row, last_row, stats)
+            update_duration_minutes(siri_ride, first_row, last_row, stats)
+            stats['num_rows'] += 1
+        session.commit()
+        pprint(dict(stats))
+        print("Processed {} / {} rows..".format(stats['num_rows'], total_rows))
     pprint(dict(stats))
     print("Processed {} / {} rows..".format(stats['num_rows'], total_rows))
-    session.commit()

--- a/open_bus_stride_etl/siri/add_ride_durations.py
+++ b/open_bus_stride_etl/siri/add_ride_durations.py
@@ -14,12 +14,14 @@ from open_bus_stride_etl import common
 # Number of siri_ride rows fetched and processed per batch. We must NOT load the
 # whole result set at once: with psycopg2 + SQLAlchemy<2 a plain `for x in query`
 # uses a client-side buffered cursor that materializes every matching row (plus
-# its ORM object) in memory. That is exactly what caused the OOM that got this
-# task disabled in Nov 2024 (https://github.com/hasadna/open-bus-stride-etl/issues/22):
-# fine for a 4-day window, fatal once a backlog built up. We instead paginate by
-# primary key (keyset) so memory is bounded to BATCH_SIZE rows regardless of how
-# far behind the task is. A server-side cursor (stream_results) is not an option
-# here because we commit mid-iteration, which would invalidate the cursor.
+# its ORM object) in memory. That OOM is why the task was disabled in Nov 2024
+# (commit d75da16, "uses a lot of RAM"); the disable in turn silently broke the
+# whole SIRI->GTFS enrichment chain, the bug this branch fixes by re-enabling the
+# task (https://github.com/hasadna/open-bus-stride-etl/issues/22). The naive load
+# was fine for a 4-day window, fatal once a backlog built up, so we paginate by
+# primary key (keyset) instead: memory stays bounded to BATCH_SIZE rows regardless
+# of how far behind the task is. A server-side cursor (stream_results) is not an
+# option here because we commit mid-iteration, which would invalidate the cursor.
 BATCH_SIZE = 1000
 
 
@@ -127,8 +129,8 @@ def main(session: Session, min_date=None, max_date=None, num_days=4):
     print("Window id range: {}..{}".format(min_id, max_id))
     # Keyset pagination over [min_id, max_id], fetching at most BATCH_SIZE rows per
     # batch so memory stays bounded regardless of how many rows match. Seeding
-    # last_id at min_id-1 (instead of 0) keeps the first batch from scanning all the
-    # older rows below the window; bounding by `id <= max_id` keeps the final batch
+    # last_id at min_id-1 keeps the first batch from scanning all the older rows
+    # below the window; bounding by `id <= max_id` keeps the final batch
     # from scanning newer rows above it (matters for a past-dated backfill). The
     # `id > last_id` bound guarantees forward progress, so there's no infinite loop
     # even for rows that legitimately stay updated_duration_minutes=NULL this run.

--- a/open_bus_stride_etl/siri/add_ride_durations.py
+++ b/open_bus_stride_etl/siri/add_ride_durations.py
@@ -1,7 +1,9 @@
+import datetime
 from pprint import pprint
 from textwrap import dedent
 from collections import defaultdict
 
+import pytz
 from sqlalchemy.engine import ResultProxy, Row
 
 from open_bus_stride_db.db import session_decorator, Session
@@ -80,26 +82,64 @@ def update_duration_minutes(siri_ride, first_row, last_row, stats):
         siri_ride.updated_duration_minutes = common.now()
 
 
+def get_scheduled_start_time_filters(min_date, max_date, num_days):
+    """Return (orm_filters, sql_where) restricting siri_ride by scheduled_start_time.
+
+    Mirrors the other siri tasks: the window is always [min_date, max_date] via
+    parse_min_max_date_strs (min_date defaults to today-num_days, max_date to today).
+    Like those tasks, the bounds are day boundaries (00:00), so the max_date day
+    itself is excluded -- e.g. the default window ends at the start of today, the
+    same way update_rides_gtfs etc. process up to (not including) today. Making the
+    window inclusive / same-day is a separate change planned across all four siri
+    tasks together. The cutoff datetimes are computed once so the ORM keyset query
+    and the raw id-range lookup use the exact same bounds.
+
+    (scheduled_start_time is timezone-aware, so we compare against tz-aware
+    datetimes; the sibling tasks pass date strings to raw SQL, which Postgres
+    interprets as the same UTC midnight given the connection's utc timezone.)"""
+    min_date, max_date = common.parse_min_max_date_strs(min_date, max_date, num_days)
+    print('min_date={} max_date={}'.format(min_date, max_date))
+    min_dt = pytz.UTC.localize(datetime.datetime.combine(min_date, datetime.time.min))
+    max_dt = pytz.UTC.localize(datetime.datetime.combine(max_date, datetime.time.min))
+    return [SiriRide.scheduled_start_time >= min_dt, SiriRide.scheduled_start_time <= max_dt], \
+        "scheduled_start_time >= '{}' and scheduled_start_time <= '{}'".format(min_dt.isoformat(), max_dt.isoformat())
+
+
 @session_decorator
-def main(session: Session):
+def main(session: Session, min_date=None, max_date=None, num_days=4):
     stats = defaultdict(int)
-    base_filter = SiriRide.scheduled_start_time > common.now_minus(days=4)
-    total_rows = session.query(SiriRide).filter(
-        SiriRide.updated_duration_minutes == None, base_filter
-    ).count()
-    print("Total rows to update: {}".format(total_rows))
-    # Keyset pagination: walk the matching rows ordered by primary key, fetching
-    # at most BATCH_SIZE ORM objects at a time. Each row we process either gets
-    # updated_duration_minutes set (dropping out of the filter) or stays NULL to
-    # be retried on a later run; either way the `id > last_id` bound guarantees
-    # forward progress within this run, so there is no risk of an infinite loop.
-    last_id = 0
+    sched_filters, sched_sql = get_scheduled_start_time_filters(min_date, max_date, num_days)
+    # Find the TRUE id range of the window cheaply. A plain `min(id) WHERE
+    # scheduled_start_time ...` makes the planner walk the pk index from the
+    # bottom (scanning every older row), because the date filter and the pk are
+    # different columns. The MATERIALIZED CTE forces it to first pull the window's
+    # ids via the scheduled_start_time index, then take min/max over that small set.
+    id_range = session.execute(dedent("""
+        with window_rows as materialized (
+            select id from siri_ride where {}
+        )
+        select min(id) min_id, max(id) max_id from window_rows
+    """).format(sched_sql)).first()
+    if id_range.min_id is None:
+        print("No siri_rides in the requested window")
+        return
+    min_id, max_id = id_range.min_id, id_range.max_id
+    print("Window id range: {}..{}".format(min_id, max_id))
+    # Keyset pagination over [min_id, max_id], fetching at most BATCH_SIZE rows per
+    # batch so memory stays bounded regardless of how many rows match. Seeding
+    # last_id at min_id-1 (instead of 0) keeps the first batch from scanning all the
+    # older rows below the window; bounding by `id <= max_id` keeps the final batch
+    # from scanning newer rows above it (matters for a past-dated backfill). The
+    # `id > last_id` bound guarantees forward progress, so there's no infinite loop
+    # even for rows that legitimately stay updated_duration_minutes=NULL this run.
+    last_id = min_id - 1
     siri_ride: SiriRide
     while True:
         rides = session.query(SiriRide).filter(
             SiriRide.updated_duration_minutes == None,
             SiriRide.id > last_id,
-            base_filter
+            SiriRide.id <= max_id,
+            *sched_filters
         ).order_by(SiriRide.id).limit(BATCH_SIZE).all()
         if not rides:
             break
@@ -112,6 +152,6 @@ def main(session: Session):
             stats['num_rows'] += 1
         session.commit()
         pprint(dict(stats))
-        print("Processed {} / {} rows..".format(stats['num_rows'], total_rows))
+        print("Processed {} rows (up to id {})..".format(stats['num_rows'], last_id))
     pprint(dict(stats))
-    print("Processed {} / {} rows..".format(stats['num_rows'], total_rows))
+    print("Processed {} rows total".format(stats['num_rows']))

--- a/open_bus_stride_etl/siri/cli.py
+++ b/open_bus_stride_etl/siri/cli.py
@@ -8,10 +8,13 @@ def siri():
 
 
 @siri.command()
-def add_ride_durations():
+@click.option('--min-date', help='Date string (%Y-%m-%d) specifying the min date to process. Defaults to today minus num_days if not provided.')
+@click.option('--max-date', help='Date string (%Y-%m-%d) specifying the max date to process. Defaults to today if not provided.')
+@click.option('--num-days', default=4, show_default=True, help='min_date defaults to today minus num_days if not provided')
+def add_ride_durations(**kwargs):
     """add duration of rides based on vehicle locations to siri_ride table"""
     from .add_ride_durations import main
-    main()
+    main(**kwargs)
 
 
 @siri.command()

--- a/open_bus_stride_etl/siri/dags.yaml
+++ b/open_bus_stride_etl/siri/dags.yaml
@@ -13,6 +13,10 @@
         type: cli
         module: open_bus_stride_etl.siri.cli
         function: add_ride_durations
+        kwargs:
+          min_date: {}
+          max_date: {}
+          num_days: {default: "4"}
 
 - name: stride-etl-siri-update-ride-stops-gtfs
   schedule_interval: "@hourly"

--- a/open_bus_stride_etl/siri/dags.yaml
+++ b/open_bus_stride_etl/siri/dags.yaml
@@ -1,18 +1,18 @@
-#- name: stride-etl-siri-add-ride-durations
-#  schedule_interval: "@hourly"
-#  description: |
-#    add siri ride durations
-#  docs:
-#    desc: |
-#      Runs hourly, finds the first and last vehicle location of each ride and 
-#      updates the following fields in DB: [[siri_ride.duration_minutes]],
-#      [[siri_ride.first_vehicle_location_id]], [[siri_ride.last_vehicle_location_id]].
-#  tasks:
-#    - id: siri-add-ride-durations
-#      config:
-#        type: cli
-#        module: open_bus_stride_etl.siri.cli
-#        function: add_ride_durations
+- name: stride-etl-siri-add-ride-durations
+  schedule_interval: "@hourly"
+  description: |
+    add siri ride durations
+  docs:
+    desc: |
+      Runs hourly, finds the first and last vehicle location of each ride and
+      updates the following fields in DB: [[siri_ride.duration_minutes]],
+      [[siri_ride.first_vehicle_location_id]], [[siri_ride.last_vehicle_location_id]].
+  tasks:
+    - id: siri-add-ride-durations
+      config:
+        type: cli
+        module: open_bus_stride_etl.siri.cli
+        function: add_ride_durations
 
 - name: stride-etl-siri-update-ride-stops-gtfs
   schedule_interval: "@hourly"


### PR DESCRIPTION
  # Description

  ## Context
  As described in issue #22, disabling add-duration broke the enrichment chain - and as a result all gtfs-siri matching since ~ October 2024.
  The disable was motivated by repeated OOM issues.

  ## Why the OOM happened:
  The loop loaded **all** matching rows into memory before iterating:
  ```python
  query = session.query(SiriRide).filter(
          SiriRide.updated_duration_minutes == None,
          SiriRide.scheduled_start_time > common.now_minus(days=4)
      )
      for siri_ride in query:   # materializes every matching row + ORM object at once
         # loop body
  ```
  With a delay of a few days the matching set grows large enough to exhaust memory.

  ## The fix:

  ### 1. Batched (keyset) pagination.
Instead of loading everything, fetch at most `BATCH_SIZE` (1000) rows at a time and advance by `id`, so only a small batch is resident per iteration:
  ```python
  while True:
          rides = session.query(SiriRide).filter(
              SiriRide.updated_duration_minutes == None,
              SiriRide.id > last_id,
              SiriRide.id <= max_id,
              *sched_filters
          ).order_by(SiriRide.id).limit(BATCH_SIZE).all()
          if not rides:
              break
          for siri_ride in rides:
              last_id = siri_ride.id
              # loop body
          session.commit()
  ```

 ### 2. Date-range support, mirroring the other siri jobs (needed for a backfill).
The task now takes `--min-date / --max-date / --num-days` (default `num_days=4`) instead of a hardcoded rolling 4-day filter.
The window's id range (`min_id`/`max_id`) is resolved once up-front with a `MATERIALIZED` CTE. The CTE pulls the in-window ids through the existing **`ix_siri_ride_scheduled_start_time`** index (a btree on `scheduled_start_time`, created together with the `siri_ride` table in migration `366df3cd0db1`) and then takes `min(id)/max(id)` over that small set. The `MATERIALIZED` keyword is what forces this order — without it the planner tends to answer `min/max(id)` by walking the primary-key index inward from the ends of the table and applying the date filter row by row, which scans every older row below the window.
So this is a one-time cost before the first batch; the per-batch keyset loop itself rides the primary-key index on `id`.
The `id <= max_id` bound keeps a past-dated batch from running off into newer rows (relevant for a backfill.
  
Memory now stays bounded to one batch no matter how far behind the task is, and the same code can target an arbitrary historical window.

Since the OOM is fixed - I uncommented the DAG that schedules it.

* Note: the default 4 days range is now [today 00:00 -4 days, today 00:00] which means today's rides are not processed until tomorrow!
This mirror the other job's defaults.

## The backfill proccess:
This PR fixes the enrichment chain going forward - new rides will be aggregated from now and forth.
To close the ~20 monthes aggregation gap we still need a one-time run of all the enrichment-chain steps over the missing duration - the new date-range parameters let that run be driven over historical windows (e.g. month by month) without OOM.