### PR TITLE
feat: Add backfill knob for add_ride_durations

### DIFF
--- a/open_bus_stride_etl/common.py
+++ b/open_bus_stride_etl/common.py
@@ -60,11 +60,9 @@ def get_db_date_str(d):
 
 
 def iter_month_chunks(min_date, max_date):
-    """Yield (chunk_min, chunk_max) date pairs splitting [min_date, max_date) into
-    calendar months. Each chunk starts on min_date (or the 1st of a month) and ends
-    on the 1st of the next month, clamped to max_date. Used to drive a long backfill
-    one month at a time so a per-chunk task keeps its memory / id-range lookup bounded
-    instead of scanning years of rows up front."""
+    """Yield (chunk_min, chunk_max) pairs splitting [min_date, max_date) on calendar
+    month boundaries, clamped to the endpoints. Lets a long backfill run a month at a
+    time to keep its memory / id-range lookup bounded."""
     chunk_min = min_date
     while chunk_min < max_date:
         if chunk_min.month == 12:

--- a/open_bus_stride_etl/common.py
+++ b/open_bus_stride_etl/common.py
@@ -59,6 +59,23 @@ def get_db_date_str(d):
     return d.strftime('%Y-%m-%d')
 
 
+def iter_month_chunks(min_date, max_date):
+    """Yield (chunk_min, chunk_max) date pairs splitting [min_date, max_date) into
+    calendar months. Each chunk starts on min_date (or the 1st of a month) and ends
+    on the 1st of the next month, clamped to max_date. Used to drive a long backfill
+    one month at a time so a per-chunk task keeps its memory / id-range lookup bounded
+    instead of scanning years of rows up front."""
+    chunk_min = min_date
+    while chunk_min < max_date:
+        if chunk_min.month == 12:
+            next_month_start = chunk_min.replace(year=chunk_min.year + 1, month=1, day=1)
+        else:
+            next_month_start = chunk_min.replace(month=chunk_min.month + 1, day=1)
+        chunk_max = min(next_month_start, max_date)
+        yield chunk_min, chunk_max
+        chunk_min = chunk_max
+
+
 @contextmanager
 def print_memory_usage(start_msg, end_msg="Done"):
     print(start_msg)

--- a/open_bus_stride_etl/siri/add_ride_durations.py
+++ b/open_bus_stride_etl/siri/add_ride_durations.py
@@ -11,17 +11,11 @@ from open_bus_stride_db.model import SiriRide
 from open_bus_stride_etl import common
 
 
-# Number of siri_ride rows fetched and processed per batch. We must NOT load the
-# whole result set at once: with psycopg2 + SQLAlchemy<2 a plain `for x in query`
-# uses a client-side buffered cursor that materializes every matching row (plus
-# its ORM object) in memory. That OOM is why the task was disabled in Nov 2024
-# (commit d75da16, "uses a lot of RAM"); the disable in turn silently broke the
-# whole SIRI->GTFS enrichment chain, the bug this branch fixes by re-enabling the
-# task (https://github.com/hasadna/open-bus-stride-etl/issues/22). The naive load
-# was fine for a 4-day window, fatal once a backlog built up, so we paginate by
-# primary key (keyset) instead: memory stays bounded to BATCH_SIZE rows regardless
-# of how far behind the task is. A server-side cursor (stream_results) is not an
-# option here because we commit mid-iteration, which would invalidate the cursor.
+# Rows fetched/processed per batch. A plain `for x in query` (psycopg2 + SQLAlchemy<2)
+# buffers every matching row client-side, which OOM'd and got this task disabled in
+# Nov 2024 (issue #22). We keyset-paginate by primary key instead, bounding memory to
+# BATCH_SIZE regardless of backlog. A server-side cursor isn't an option: we commit
+# mid-iteration, which would invalidate it.
 BATCH_SIZE = 1000
 
 
@@ -127,13 +121,10 @@ def main(session: Session, min_date=None, max_date=None, num_days=4):
         return
     min_id, max_id = id_range.min_id, id_range.max_id
     print("Window id range: {}..{}".format(min_id, max_id))
-    # Keyset pagination over [min_id, max_id], fetching at most BATCH_SIZE rows per
-    # batch so memory stays bounded regardless of how many rows match. Seeding
-    # last_id at min_id-1 keeps the first batch from scanning all the older rows
-    # below the window; bounding by `id <= max_id` keeps the final batch
-    # from scanning newer rows above it (matters for a past-dated backfill). The
-    # `id > last_id` bound guarantees forward progress, so there's no infinite loop
-    # even for rows that legitimately stay updated_duration_minutes=NULL this run.
+    # Keyset pagination over [min_id, max_id]. last_id starts at min_id-1 and the
+    # `id <= max_id` bound keeps batches from scanning rows outside the window (matters
+    # for a past-dated backfill). `id > last_id` guarantees forward progress, so rows
+    # that legitimately stay updated_duration_minutes=NULL won't loop forever.
     last_id = min_id - 1
     siri_ride: SiriRide
     while True:
@@ -162,19 +153,12 @@ def main(session: Session, min_date=None, max_date=None, num_days=4):
 def backfill(min_date, max_date):
     """Run add_ride_durations over a historical window one calendar month at a time.
 
-    This is the one-time backfill for issue #22 (durations were never set from ~Oct
-    2024 on, which left LineProfile ride durations empty and gated the whole SIRI->GTFS
-    chain). main() resolves the window's id-range up front with a MATERIALIZED CTE; over
-    a multi-year range that would materialize every in-window id before the first batch.
-    Splitting into months keeps that lookup (and each run's grouping) bounded. Every
-    per-month run is fully idempotent -- it only touches rows where
-    updated_duration_minutes IS NULL -- so an already-enriched month or a re-run after a
-    crash is a cheap no-op, and running the full range also fills any stray older gaps.
-    The rolling hourly DAG keeps handling recent days unchanged.
-
-    Unlike the rolling task there is no num_days fallback: a backfill must be given an
-    explicit window, so a config-less trigger fails loudly instead of quietly doing the
-    last few days."""
+    One-time backfill for issue #22 (durations unset from ~Oct 2024 on). main() resolves
+    the window's id-range up front with a MATERIALIZED CTE; over a multi-year range that
+    would materialize every in-window id before the first batch, so we split into months
+    to keep the lookup bounded. Idempotent (only touches updated_duration_minutes IS NULL
+    rows), so already-enriched months and crash re-runs are cheap no-ops. Requires an
+    explicit window -- no num_days fallback -- so a config-less trigger fails loudly."""
     assert min_date and max_date, "backfill requires an explicit min_date and max_date"
     min_date, max_date = common.parse_date_str(min_date), common.parse_date_str(max_date)
     assert min_date <= max_date

--- a/open_bus_stride_etl/siri/add_ride_durations.py
+++ b/open_bus_stride_etl/siri/add_ride_durations.py
@@ -157,3 +157,28 @@ def main(session: Session, min_date=None, max_date=None, num_days=4):
         print("Processed {} rows (up to id {})..".format(stats['num_rows'], last_id))
     pprint(dict(stats))
     print("Processed {} rows total".format(stats['num_rows']))
+
+
+def backfill(min_date, max_date):
+    """Run add_ride_durations over a historical window one calendar month at a time.
+
+    This is the one-time backfill for issue #22 (durations were never set from ~Oct
+    2024 on, which left LineProfile ride durations empty and gated the whole SIRI->GTFS
+    chain). main() resolves the window's id-range up front with a MATERIALIZED CTE; over
+    a multi-year range that would materialize every in-window id before the first batch.
+    Splitting into months keeps that lookup (and each run's grouping) bounded. Every
+    per-month run is fully idempotent -- it only touches rows where
+    updated_duration_minutes IS NULL -- so an already-enriched month or a re-run after a
+    crash is a cheap no-op, and running the full range also fills any stray older gaps.
+    The rolling hourly DAG keeps handling recent days unchanged.
+
+    Unlike the rolling task there is no num_days fallback: a backfill must be given an
+    explicit window, so a config-less trigger fails loudly instead of quietly doing the
+    last few days."""
+    assert min_date and max_date, "backfill requires an explicit min_date and max_date"
+    min_date, max_date = common.parse_date_str(min_date), common.parse_date_str(max_date)
+    assert min_date <= max_date
+    print("Backfilling ride durations over {} .. {} in monthly chunks".format(min_date, max_date))
+    for chunk_min, chunk_max in common.iter_month_chunks(min_date, max_date):
+        print("\n===== month chunk {} .. {} =====".format(chunk_min, chunk_max))
+        main(min_date=common.get_db_date_str(chunk_min), max_date=common.get_db_date_str(chunk_max))

--- a/open_bus_stride_etl/siri/add_ride_durations.py
+++ b/open_bus_stride_etl/siri/add_ride_durations.py
@@ -163,6 +163,10 @@ def backfill(min_date, max_date):
     min_date, max_date = common.parse_date_str(min_date), common.parse_date_str(max_date)
     assert min_date <= max_date
     print("Backfilling ride durations over {} .. {} in monthly chunks".format(min_date, max_date))
-    for chunk_min, chunk_max in common.iter_month_chunks(min_date, max_date):
+    # main() treats its max_date as an exclusive day-boundary (scheduled_start_time <=
+    # max_date 00:00) -- correct for the rolling daily job, but it would drop the final
+    # day of an explicit backfill window. Extend the chunker's end by one day so the
+    # full inclusive [min_date, max_date] window is processed, last day included.
+    for chunk_min, chunk_max in common.iter_month_chunks(min_date, max_date + datetime.timedelta(days=1)):
         print("\n===== month chunk {} .. {} =====".format(chunk_min, chunk_max))
         main(min_date=common.get_db_date_str(chunk_min), max_date=common.get_db_date_str(chunk_max))

--- a/open_bus_stride_etl/siri/cli.py
+++ b/open_bus_stride_etl/siri/cli.py
@@ -18,6 +18,15 @@ def add_ride_durations(**kwargs):
 
 
 @siri.command()
+@click.option('--min-date', required=True, help='Date string (%Y-%m-%d) for the start of the backfill window (required).')
+@click.option('--max-date', required=True, help='Date string (%Y-%m-%d) for the end of the backfill window (required).')
+def add_ride_durations_backfill(**kwargs):
+    """one-time backfill of add_ride_durations over a historical window, one month at a time (issue #22)"""
+    from .add_ride_durations import backfill
+    backfill(**kwargs)
+
+
+@siri.command()
 @click.option('--min-date', help='Date string (%Y-%m-%d) specifying the min date to process. Defaults to today minus num_days if not provided.')
 @click.option('--max-date', help='Date string (%Y-%m-%d) specifying the max date to process. Defaults to today if not provided.')
 @click.option('--num-days', default=1, show_default=True, help='min_date defaults to today minus num_days if not provided')

--- a/open_bus_stride_etl/siri/dags.yaml
+++ b/open_bus_stride_etl/siri/dags.yaml
@@ -18,6 +18,32 @@
           max_date: {}
           num_days: {default: "4"}
 
+- name: stride-etl-siri-add-ride-durations-backfill
+  schedule_interval: null
+  disable_alert_after_minutes: true
+  description: |
+    one-time backfill of siri ride durations over a historical window, month by month
+  docs:
+    desc: |
+      Manually-triggered one-time job (issue #22). Runs add-ride-durations over an
+      arbitrary historical window, splitting it into calendar-month chunks to keep
+      memory and the per-run id-range lookup bounded. The window is passed at trigger
+      time via the dag run config, e.g. {"min_date": "2026-05-01", "max_date": "2026-06-01"};
+      both are required, so a config-less trigger fails loudly instead of quietly doing
+      the last few days. Idempotent: only
+      processes siri_ride rows whose updated_duration_minutes is still null, so re-runs
+      and already-enriched months are cheap no-ops. Not scheduled (schedule_interval
+      null) and the run-time alert is disabled, since a full backfill runs long by design.
+  tasks:
+    - id: siri-add-ride-durations-backfill
+      config:
+        type: cli
+        module: open_bus_stride_etl.siri.cli
+        function: add_ride_durations_backfill
+        kwargs:
+          min_date: {}
+          max_date: {}
+
 - name: stride-etl-siri-update-ride-stops-gtfs
   schedule_interval: "@hourly"
   description: |

--- a/open_bus_stride_etl/siri/dags.yaml
+++ b/open_bus_stride_etl/siri/dags.yaml
@@ -25,15 +25,13 @@
     one-time backfill of siri ride durations over a historical window, month by month
   docs:
     desc: |
-      Manually-triggered one-time job (issue #22). Runs add-ride-durations over an
-      arbitrary historical window, splitting it into calendar-month chunks to keep
-      memory and the per-run id-range lookup bounded. The window is passed at trigger
-      time via the dag run config, e.g. {"min_date": "2026-05-01", "max_date": "2026-06-01"};
-      both are required, so a config-less trigger fails loudly instead of quietly doing
-      the last few days. Idempotent: only
-      processes siri_ride rows whose updated_duration_minutes is still null, so re-runs
-      and already-enriched months are cheap no-ops. Not scheduled (schedule_interval
-      null) and the run-time alert is disabled, since a full backfill runs long by design.
+      Manually-triggered one-time backfill (issue #22). Runs add-ride-durations over a
+      historical window, split into calendar-month chunks to keep memory and the id-range
+      lookup bounded. Window is passed via the dag run config, e.g.
+      {"min_date": "2026-05-01", "max_date": "2026-06-01"}; both required, so a config-less
+      trigger fails loudly. Idempotent: only processes rows with null
+      updated_duration_minutes, so re-runs and already-enriched months are cheap no-ops.
+      Unscheduled and run-time alert disabled, since a full backfill runs long by design.
   tasks:
     - id: siri-add-ride-durations-backfill
       config:


### PR DESCRIPTION
# Context
The backfill process has several steps:
1. add_ride_durations (can run anytime)
2. update_rides_gtfs (must run AFTER 1)
3. update_ride_stops_gtfs (must run AFTER 1)
4. update_ride_stops_vehicle_locations (must run AFTER 1 & 3)

* We can run them as layers and complete one at a time.
* I suggest we run the backfill from the start of the db - not only on the big gap. This way it will fill any casual tiny gaps here and there - and it is a no-op for already enriched rides.

# Waht was added here
## A helper that takes a date range and return sub-ranges spitted by month.
This is needed in order to chunk the task to isolated sub-tasks.
This helper is useful for all of the backfill steps.

## A `backfill` function that get `min_date` and `max_date` and iterate the set_ride_duration for every month.

## A cli wrapper that call the backfill.
## DAG that can run that cli command.