### PR TITLE
docs: remove unused stride-api/stride-client sibling deps from local dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,9 @@ Upgrade pip
 venv/bin/pip install --upgrade pip
 ```
 
-You should have a clone of the following repositories in sibling directories:
+You should have a clone of the following repository in a sibling directory:
 
 * `../open-bus-stride-db`: https://github.com/hasadna/open-bus-stride-db
-* `../open-bus-stride-api`: https://github.com/hasadna/open-bus-stride-api
-* `../open-bus-stride-client`: https://github.com/hasadna/open-bus-stride-client
 
 Install dev requirements (this installs above repository as well as this repository as editable for development):
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,5 @@
 -r ../open-bus-stride-db/requirements.txt
 -e ../open-bus-stride-db
 
--r ../open-bus-stride-api/requirements.txt
--e ../open-bus-stride-api
-
--e ../open-bus-stride-client[all]
-
 -r requirements.txt
 -e .


### PR DESCRIPTION
## Problem
The README told local developers to clone `open-bus-stride-api` and `open-bus-stride-client` as sibling repos, and `requirements-dev.txt` installed both editable. I searched this repo's entire source tree for `stride_api`/`stride_client` imports and found none - only `open_bus_stride_db` is actually used anywhere in `open_bus_stride_etl/`.

## Fix
Removed both from the README's sibling-clone instructions and from `requirements-dev.txt`. Only `open-bus-stride-db` remains, matching what the code actually imports.

## Scope note (not fixed here, flagging for visibility)
While investigating I found `bin/get_stride_etl_requirements.py` (invoked by `.github/workflows/ci.yml:41`) *also* bakes `open-bus-stride-api` and `open-bus-stride-client[all]` into the generated `requirements-stride-etl.txt` that's consumed by the shared Airflow venv in `open-bus-pipelines` - with, as far as I can tell, the same lack of justification (no import anywhere). That's a different and higher-stakes change since it affects what actually gets installed into the production venv, not just local dev setup, so I intentionally left it out of this PR. Happy to open a separate PR for that if a maintainer confirms it's also dead weight.

## Test plan
- [x] `grep -rn "stride_api\|stride_client" --include="*.py"` across the whole repo → no matches outside this cleanup.
- [x] No test suite exists in this repo to run (confirmed no `tests/` directory).
- [x] Docs/dev-setup-only change, no application code touched.