### PR TITLE
Decouple the ride_duration gate from enrichment tasks

### DIFF
--- a/open_bus_stride_etl/siri/common.py
+++ b/open_bus_stride_etl/siri/common.py
@@ -5,6 +5,24 @@ from .. import common
 from open_bus_stride_db import db
 
 
+# A ride's SIRI data keeps growing while the ride is in progress - siri-etl appends
+# siri_ride_stop / siri_vehicle_location rows for as long as snapshots for it keep arriving - so
+# the GTFS-matching jobs may only touch rides which are already over, otherwise they leave the
+# ride's later stops unmatched. 12 hours after the scheduled start covers the longest scheduled
+# ride plus SIRI ingestion lag.
+#
+# scheduled_start_time is "timestamp without time zone" holding UTC (DateTimeWithTimeZone strips
+# the offset on write), so now() is converted to naive UTC as well: a bare now() is a timestamptz,
+# and comparing it against this column casts it using the session's TimeZone setting, which shifts
+# the interval by the local UTC offset.
+RIDE_DATA_SETTLED_HOURS = 12
+RIDE_DATA_SETTLED_SQL = (
+    "siri_ride.scheduled_start_time < (now() at time zone 'utc') - interval '{} hours'".format(
+        RIDE_DATA_SETTLED_HOURS
+    )
+)
+
+
 def iterate_siri_route_id_dates(where_sql=None, extra_from_sql=None):
     if where_sql:
         where_sql = 'where {}'.format(where_sql)

--- a/open_bus_stride_etl/siri/update_ride_stops_gtfs.py
+++ b/open_bus_stride_etl/siri/update_ride_stops_gtfs.py
@@ -7,7 +7,7 @@ from sqlalchemy.engine import ResultProxy
 
 from open_bus_stride_db import db
 
-from .common import iterate_siri_route_id_dates
+from .common import iterate_siri_route_id_dates, RIDE_DATA_SETTLED_SQL
 from ..common import parse_min_max_date_strs, get_db_date_str
 
 
@@ -23,15 +23,17 @@ def main(min_date, max_date, num_days):
         where_sql=dedent("""
             siri_ride_stop.siri_stop_id = siri_stop.id
             and siri_ride_stop.siri_ride_id = siri_ride.id
-            -- if we have updated_duration_minutes it means we updated the duration of the ride
-            -- so we have all the ride stops data which we must ensure before making these updates
-            and siri_ride.updated_duration_minutes is not null
+            -- only rides which are already over, see RIDE_DATA_SETTLED_SQL
+            and {ride_data_settled}
             and siri_ride_stop.gtfs_stop_id is null
             and gtfs_stop.code = siri_stop.code
             and gtfs_stop.date = '{min_date}'
             and siri_ride.scheduled_start_time >= '{min_date}'
             and siri_ride.scheduled_start_time < '{max_date}'
-        """).format(min_date=get_db_date_str(min_date), max_date=get_db_date_str(max_date))
+        """).format(
+            min_date=get_db_date_str(min_date), max_date=get_db_date_str(max_date),
+            ride_data_settled=RIDE_DATA_SETTLED_SQL
+        )
     ):
         for siri_route_id in siri_route_ids:
             stats['updated_siri_routes'] += 1
@@ -43,12 +45,13 @@ def main(min_date, max_date, num_days):
                     from siri_stop, siri_ride, gtfs_stop
                     where siri_ride_stop.siri_stop_id = siri_stop.id
                     and siri_ride_stop.siri_ride_id = siri_ride.id
-                    and siri_ride.updated_duration_minutes is not null
+                    -- only rides which are already over, see RIDE_DATA_SETTLED_SQL
+                    and {ride_data_settled}
                     and siri_ride_stop.gtfs_stop_id is null
                     and gtfs_stop.code = siri_stop.code
                     and gtfs_stop.date = '{}'
                     and siri_ride.siri_route_id = {};
-                """).format(date, siri_route_id))
+                """).format(date, siri_route_id, ride_data_settled=RIDE_DATA_SETTLED_SQL))
                 stats['updated_ride_stops'] += res.rowcount
                 session.commit()
                 pprint(dict(stats))

--- a/open_bus_stride_etl/siri/update_rides_gtfs.py
+++ b/open_bus_stride_etl/siri/update_rides_gtfs.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 from open_bus_stride_db import db
 
-from .common import iterate_siri_route_id_dates
+from .common import iterate_siri_route_id_dates, RIDE_DATA_SETTLED_SQL
 from ..common import parse_min_max_date_strs, get_db_date_str
 
 GTFS_ROTE_DATE_FORMAT = "%Y-%m-%d"
@@ -21,11 +21,10 @@ UPDATE_ROUTE_GTFS_RIDE_SQL_TEMPLATE = dedent("""
     and gtfs_route.date = '{date}'
     and siri_ride.scheduled_start_time > gtfs_ride.start_time - '{minutes} minutes'::interval
     and siri_ride.scheduled_start_time < gtfs_ride.start_time + '{minutes} minutes'::interval
-    -- if we have updated_duration_minutes it means we updated the duration of the ride
-    -- so we have all the ride stops data which we must ensure before making these updates
-    and siri_ride.updated_duration_minutes is not null
+    -- only rides which are already over, see RIDE_DATA_SETTLED_SQL
+    and {ride_data_settled}
     {extra_where}
-""")
+""").replace('{ride_data_settled}', RIDE_DATA_SETTLED_SQL)
 
 UPDATE_SCHEDULED_GTFS_RIDE_SQL_TEMPLATE = dedent("""
     update siri_ride
@@ -38,10 +37,9 @@ UPDATE_SCHEDULED_GTFS_RIDE_SQL_TEMPLATE = dedent("""
     and siri_route.id = siri_ride.siri_route_id
     and gtfs_route.date between '{start_date}' and '{end_date}' 
     and siri_ride.scheduled_start_time = gtfs_ride.start_time
-    -- if we have updated_duration_minutes it means we updated the duration of the ride
-    -- so we have all the ride stops data which we must ensure before making these updates
-    and siri_ride.updated_duration_minutes is not null
-""")
+    -- only rides which are already over, see RIDE_DATA_SETTLED_SQL
+    and {ride_data_settled}
+""").replace('{ride_data_settled}', RIDE_DATA_SETTLED_SQL)
 
 def main(min_date, max_date, num_days):
     min_date, max_date = parse_min_max_date_strs(min_date, max_date, num_days)
@@ -53,10 +51,12 @@ def main(min_date, max_date, num_days):
             siri_ride.gtfs_ride_id is null
             and siri_ride.scheduled_start_time >= '{min_date}'
             and siri_ride.scheduled_start_time <= '{max_date}'
-            -- if we have updated_duration_minutes it means we updated the duration of the ride
-            -- so we have all the ride stops data which we must ensure before making these updates
-            and siri_ride.updated_duration_minutes is not null
-        """).format(min_date=get_db_date_str(min_date), max_date=get_db_date_str(max_date))
+            -- only rides which are already over, see RIDE_DATA_SETTLED_SQL
+            and {ride_data_settled}
+        """).format(
+            min_date=get_db_date_str(min_date), max_date=get_db_date_str(max_date),
+            ride_data_settled=RIDE_DATA_SETTLED_SQL
+        )
     ):
         updated_journey_gtfs_ride_ids = 0
         updated_route_gtfs_ride_ids = 0
@@ -72,10 +72,9 @@ def main(min_date, max_date, num_days):
                 where gtfs_ride.journey_ref = split_part(siri_ride.journey_ref, '-', 4) || '_' || split_part(siri_ride.journey_ref, '-', 3) || split_part(siri_ride.journey_ref, '-', 2) || substr(split_part(siri_ride.journey_ref, '-', 1), 3)
                 and gtfs_route.id = gtfs_ride.gtfs_route_id
                 and gtfs_route.date = '{}'
-                -- if we have updated_duration_minutes it means we updated the duration of the ride
-                -- so we have all the ride stops data which we must ensure before making these updates
-                and siri_ride.updated_duration_minutes is not null;
-            """).format(date))
+                -- only rides which are already over, see RIDE_DATA_SETTLED_SQL
+                and {ride_data_settled};
+            """).format(date, ride_data_settled=RIDE_DATA_SETTLED_SQL))
             updated_journey_gtfs_ride_ids += res.rowcount
             updated_route_gtfs_ride_ids += session.execute(
                 UPDATE_ROUTE_GTFS_RIDE_SQL_TEMPLATE.format(


### PR DESCRIPTION
Enrichment jobs gated on ride_durations to not be null in order to assert that the ride is fully ingested.
Since add_ride_durations currently lag behind - it is better to remove the gate and assert that directly instead.